### PR TITLE
Link to use_small_heuristics from max_width

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -1666,7 +1666,7 @@ Maximum width of each line
 - **Possible values**: any positive integer
 - **Stable**: Yes
 
-See also [`error_on_line_overflow`](#error_on_line_overflow).
+See also [`error_on_line_overflow`](#error_on_line_overflow) and [`use_small_heuristics`](#use_small_heuristics).
 
 ## `merge_derives`
 


### PR DESCRIPTION
When trying to figure out how to change the maximum line width, I was confused since `max_width` didn't seem to match what was actually happening because of the `use_small_heuristics` factors. Adding this link should make it easier to realize this for new users.